### PR TITLE
Fix tag release with vX.X.X tags

### DIFF
--- a/bin/tag-release
+++ b/bin/tag-release
@@ -69,7 +69,7 @@ function getPreviousTag(SymfonyStyle $ui, string $directory, string $branch): ?s
 
     $previousTag = null;
     foreach ($equalTags as $equalTag) {
-        if ($previousTag === null || version_compare($previousTag, $equalTag, '<')) {
+        if ($previousTag === null || version_compare(trim($previousTag, 'v'), trim($equalTag, 'v'), '<')) {
             $previousTag = $equalTag;
         }
     }


### PR DESCRIPTION
Releases with prefixed v like `v2.5.2` should also work.